### PR TITLE
Fix/sso cookie domain inconsitency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Always set domain property of SSO cookie upon successful login. The cookie domain can explicitly be set by environment/config variable, otherwise the application will try to extract the TLD to be used as cookie domain.
+- SSO Cookie domain is now prepended with a dot(punctuation) before TLD.
+
 ## [1.0.1-beta]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Always set domain property of SSO cookie upon successful login. The cookie domain can explicitly be set by environment/config variable, otherwise the application will try to extract the TLD to be used as cookie domain.
-- SSO Cookie domain is now prepended with a dot(punctuation) before TLD.
+- Always set domain property of SSO cookie upon successful login. The cookie domain can explicitly be set by environment/config variable, otherwise the application will try to extract the SLD to be used as cookie domain.
+- SSO Cookie domain is now prepended with a dot(punctuation) before SLD.
 
 ## [1.0.1-beta]
 

--- a/app/public/js/main.js
+++ b/app/public/js/main.js
@@ -29,7 +29,11 @@ const onLogin = () => {
           const json = JSON.parse(xhr.response);
           let cookie = SSO_COOKIE_NAME + "=" + json.sso + ";path=/";
           if (json.ssoDomain !== undefined) {
-            cookie += ";domain=" + json.ssoDomain;
+            cookie += ";domain=." + json.ssoDomain;
+          } else {
+            const split = location.hostname.split(".");
+            const tld = split.slice(split.length - 2).join(".");
+            cookie += ";domain=." + tld;
           }
           document.cookie = cookie;
 

--- a/app/public/js/main.js
+++ b/app/public/js/main.js
@@ -32,8 +32,8 @@ const onLogin = () => {
             cookie += ";domain=." + json.ssoDomain;
           } else {
             const split = location.hostname.split(".");
-            const tld = split.slice(split.length - 2).join(".");
-            cookie += ";domain=." + tld;
+            const sld = split.slice(split.length - 2).join(".");
+            cookie += ";domain=." + sld;
           }
           document.cookie = cookie;
 


### PR DESCRIPTION
### Fixed

- Always set domain property of SSO cookie upon successful login. The cookie domain can explicitly be set by environment/config variable, otherwise the application will try to extract the TLD to be used as cookie domain.
- SSO Cookie domain is now prepended with a dot(punctuation) before TLD.