### PR TITLE
Set check-connectivity version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.19.0",
-    "check-connectivity": "git+https://git@github.com/MagnumOpuses/check-connectivity.git",
+    "check-connectivity": "git+https://git@github.com/MagnumOpuses/check-connectivity.git#8a073c1",
     "check-dependencies": "^1.1.0",
     "dotenv": "^8.2.0",
     "ejs": "^3.0.1",


### PR DESCRIPTION
**What does this implement/fix?**

Node packages directly from GitHub, does not automatically self update upon `npm install`.  
As a result, this may lead to uncertainty of which package version is installed and utilized...

So in order to solve this issue, we have to specify exact version(commit id).  
Additionally, if the specified version later is incremented(higher commit id), then `npm install` will successfully upgrade the installed package to the new version. Effectively solving the uncertainty issue.